### PR TITLE
Rename KMS key for legibility, plus task-execution-role-policy change

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module "ecs_saf_rds_mysql_runner" {
   secret_rds_credentials_arn    = data.aws_secretsmanager_secret_version.rds_credentials.arn
 
   // if using AWS Parameter Store
-  kms_key_arn                     = aws_kms_key.kms_key_for_rds_secrets.arn
+  # parameter_store_enc_kms_key   = aws_kms_key.kms_key_for_rds_secrets.arn
   # secret_mysql_username_arn     = aws_ssm_parameter.username.arn
   # secret_mysql_password_arn     = aws_ssm_parameter.password.arn
   # secret_mysql_hostname_arn     = aws_ssm_parameter.hostname.arn

--- a/main.tf
+++ b/main.tf
@@ -208,7 +208,7 @@ resource "aws_iam_role_policy" "task_execution_role_policy" {
     username_arn       = var.secret_mysql_username_arn,
     password_arn       = var.secret_mysql_password_arn,
     hostname_arn       = var.secret_mysql_hostname_arn,
-    kms_key_arn        = var.kms_key_arn
+    parameter_store_enc_kms_key        = var.parameter_store_enc_kms_key
   })
 }
 

--- a/task-execution-role-policy.tpl
+++ b/task-execution-role-policy.tpl
@@ -40,8 +40,8 @@
         %{ endif }
         "arn:${partition}:secretsmanager:${region}:${caller_id}:secret:/${app_name}-${environment}*"
       ]
-    },
     %{ if secretsManager_arn == ""}
+    },
     {
       "Sid": "",
       "Effect": "Allow",
@@ -54,7 +54,6 @@
         "${hostname_arn}"
       ]
     },
-    %{ endif }
     {
       "Sid": "",
       "Effect": "Allow",
@@ -62,8 +61,9 @@
         "kms:Decrypt"
       ],
       "Resource": [
-        "${kms_key_arn}"
+        "${parameter_store_enc_kms_key}"
       ]
+    %{ endif }
     }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,9 +8,10 @@ variable "task_name" {
   description = "Name of the task to be run"
 }
 
-variable "kms_key_arn" {
+variable "parameter_store_enc_kms_key" {
   type        = string
-  description = "KMS key for secret decryption"
+  description = "KMS key for parameter store secret decryption"
+  default     = ""
 }
 
 variable "ecs_cluster_arn" {


### PR DESCRIPTION
This PR does 3 things:
* Rename kms_key_arn to parameter_store_enc_kms_key for legibility
* Make parameter_store_enc_kms_key a non-required field, because if the user is using Secrets Manager they should not have to populate this field
* Change the line location of the if logic to make parsing work and to remove unnecessary statement if kms key is not provided