### PR TITLE
simplify cloudwatch log group logic to avoid race conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,11 @@ module "ecs_saf_rds_mysql_runner" {
 
 You must provide EITHER an AWS Secrets Manager secret (secret_rds_credentials_arn) OR AWS Parameter Store secrets (secret_mysql_username_arn, secret_mysql_password_arn, secret_mysql_hostname_arn) and a corresponding AWS KMS key, as shown above.
 
-In addition, the mysql_port, version, users, etc. are also required.
+In addition, the logs_cloudwatch_group_arn, mysql_port, version, users, etc. are also required.
 ## Optional Parameters
 
 | Name | Default Value | Description |
 |------|---------|---------|
-| logs_cloudwatch_group_arn | "" | CloudWatch log group arn, overrides values of logs_cloudwatch_retention & logs_cloudwatch_group |
 | ecs_cluster_arn | "" | You can provide your own ECS Cluster ARN to prevent a new provisioning of one for this task |
 | s3_results_bucket | "" | Bucket value to store scan results, if value is a valid bucket path json files will be streamed to it. |
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,8 +37,7 @@ variable "logs_cloudwatch_retention" {
 }
 
 variable "logs_cloudwatch_group_arn" {
-  description = "CloudWatch log group arn, overrides values of logs_cloudwatch_retention & logs_cloudwatch_group"
-  default     = ""
+  description = "CloudWatch log group arn for container logs"
   type        = string
 }
 


### PR DESCRIPTION
## Description 

The goal of this pr is to create a work around a race condition which forced developers to use `--target` switch to deploy the module. This problem arose because we had defensive code that would spin up a cloudwatch log group if none was provided.  this included creating a KMS key. However side affect of this feature was the race condition. This PR simplifies that logic and now expects cloudwatch log group arn to be provided externally and does not auto create a cloudwatch log group or a kms key to encrypt.

```
aws_s3_bucket.saf_rds_mysql_results: Refreshing state... [id=saf-rds-mysql-scanner-results-test]

Error: Invalid count argument

  on ../../../terraform-aws-cms-ars-saf-ecs-rds-mysql-runner/main.tf line 88, in resource "aws_kms_key" "log_enc_key":
  88:   count               = var.logs_cloudwatch_group_arn == "" ? 1 : 0 // do not create resource if cloudwatch log group arn is supplied as a variable
```

TL;DR: Cloudwatch log group ARN is required field and now developers don't need to do targeted terraform plans to cleanly deploy this module.

