### PR TITLE
make ecs cluster a required value so most deps are injected

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,11 @@ module "ecs_saf_rds_mysql_runner" {
 
 You must provide EITHER an AWS Secrets Manager secret (secret_rds_credentials_arn) OR AWS Parameter Store secrets (secret_mysql_username_arn, secret_mysql_password_arn, secret_mysql_hostname_arn) and a corresponding AWS KMS key, as shown above.
 
-In addition, the logs_cloudwatch_group_arn, mysql_port, version, users, etc. are also required.
+In addition, the logs_cloudwatch_group_arn, ecs_cluster_arn, mysql_port, version, users, etc. are also required.
 ## Optional Parameters
 
 | Name | Default Value | Description |
 |------|---------|---------|
-| ecs_cluster_arn | "" | You can provide your own ECS Cluster ARN to prevent a new provisioning of one for this task |
 | s3_results_bucket | "" | Bucket value to store scan results, if value is a valid bucket path json files will be streamed to it. |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,6 @@ variable "parameter_store_enc_kms_key" {
 variable "ecs_cluster_arn" {
   description = "ECS cluster ARN to use for running this profile"
   type        = string
-  default     = ""
 }
 
 variable "ecs_vpc_id" {


### PR DESCRIPTION
## Description

The goal of this PR is to simplify dependencies. As part of this [ADR](https://confluenceent.cms.gov/display/CMCSMAC/0005+-+Inject+dependencies) we decided that dependencies should be injected rather than created by the module where possible. 